### PR TITLE
Build openapi files with redoc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,10 @@ jobs:
         with:
           ruby-version: '3.1.3'
           bundler-cache: true
+      - name: Install redoc
+        run: npm install -g redoc
+      - name: Install redoc-cli
+        run: npm install -g redoc-cli
       - name: Install Just
         run: sudo snap install --edge --classic just
       - name: Build

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -26,6 +26,10 @@ jobs:
           bundler-cache: true
       - name: Install Just
         run: sudo snap install --edge --classic just
+      - name: Install redoc
+        run: npm install -g redoc
+      - name: Install redoc-cli
+        run: npm install -g redoc-cli
       - name: Build
         run: just build
       - name: "Deploy to AWS S3"

--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,16 @@
 # limitations under the License.
 
 #jekyll stuff
-.jekyll-cache/
-_site/
+/.jekyll-cache/
+/.jekyll-metadata
+/_site/
 /database/
 /Gemfile.lock
+
+/community/planning/rest_api/api/
+/docs/0.1/api/
+/docs/0.2/api/
+/docs/0.3/api/
+/docs/0.4/api/
 
 **/.DS_Store

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-# Copyright 2023 Bitwise IO, Inc.
+# Copyright 2023-2024 Bitwise IO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build:
+build: build-jekyll
+
+build-api:
+    #!/usr/bin/env sh
+    set -e
+    for version in 0.1 0.2 0.3 0.4
+    do
+        cmd="redoc-cli build docs/$version/references/api/openapi.yaml -o docs/$version/api/index.html"
+        echo "\033[1m$cmd\033[0m"
+        $cmd
+
+        echo
+        echo "** In MacOS: open docs/$version/api/index.html"
+    done
+
+    cmd="redoc-cli build community/planning/rest_api/openapi.yaml -o community/planning/rest_api/api/index.html"
+    echo "\033[1m$cmd\033[0m"
+    $cmd
+
+    echo
+    echo "** In MacOS: open community/planning/rest_api/api/index.html"
+
+    echo "\n\033[92mBuild API Success\033[0m\n"
+
+build-jekyll: build-api
     #!/usr/bin/env sh
     set -e
 
@@ -29,6 +53,11 @@ clean:
     rm -rf \
         .jekyll-metadata/ \
         _site/ \
+        docs/0.1/api/ \
+        docs/0.2/api/ \
+        docs/0.3/api/ \
+        docs/0.4/api/ \
+        community/planning/rest_api/api/ \
         Gemfile.lock
 
 install-jekyll-via-brew:
@@ -56,7 +85,7 @@ install-mdl:
 
     gem install mdl
 
-run:
+run: build-api
     #!/usr/bin/env sh
     set -e
 


### PR DESCRIPTION
This was previously omitted in the transition away from docker.